### PR TITLE
Fix nan bug for mountain maps in batched mode

### DIFF
--- a/jux/map_generator/generator.py
+++ b/jux/map_generator/generator.py
@@ -291,6 +291,7 @@ def solve_poisson(f):
     f = cx[:, None] + cy[None, :] - 2
 
     dct = jnp.divide(dct, f) * (f != 0)
+    dct = jnp.nan_to_num(dct, copy=True)
     dct = dct * (f != 0)
 
     # Return to normal space


### PR DESCRIPTION
There's a strange bug when using batched mode, the original code

```
dct = jnp.divide(dct, f) * (f != 0)
dct = dct * (f != 0)
```
creates NaN values when f has some zeros in it but doesn't create them when not batched. This would cause all mountain maps to just be 0s.

Not sure why but this is a simple fix.